### PR TITLE
Fixup bundle tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq --fix-missing && apt-get install -y --no-install-recommen
     libicu-dev chrpath bison libffi-dev libgdbm-dev libqdbm-dev \
     libreadline-dev libyaml-dev libharfbuzz-dev libgmp-dev patchelf python3 python3-pip python3-dev \
     lcov wget ninja-build gpg-agent software-properties-common ca-certificates pkgconf \
-    jq zip unzip p7zip-full p7zip-rar aria2 file openssh-client tree bash-completion ripgrep \
+    jq zip unzip p7zip-full p7zip-rar aria2 file openssh-client tree bash-completion ripgrep tmate \
     groff less \
     && ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,10 @@ RUN apt-get install -y autoconf patch build-essential rustc libssl-dev libyaml-d
     && rbenv global ${RUBY_VERSION} \
     && ruby --version \
     && ruby -e "require 'openssl'; puts OpenSSL::VERSION" \
-    && gem install bundler -v "${BUNDLER_VERSION}"
+    && gem install bundler -v "${BUNDLER_VERSION}" \
+    && echo "Shenanigans to fix the bundle tests" \
+    && mkdir -p /opt/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec \
+    && ln -sf ../exe/bundle /opt/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle
 
 # RUN cd /tmp \
 #     && echo "Fixing CA certificate issue" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
 ARG PYTHON_VERSION=3.12.2
 # NOTE: We're placing pyenv and rbenv at /opt/ instead of $HOME/.pyenv, because the entire HOME directory is bind-mounted on CI, so it would be obscured by the mount
 ENV PYENV_ROOT=/opt/pyenv \
-    PATH=/opt/pyenv/shims:/opt/pyenv/bin:${PATH} \
+    PATH=/opt/pyenv/versions/${PYTHON_VERSION}/bin:/opt/pyenv/shims:/opt/pyenv/bin:${PATH} \
     Python_ROOT_DIR=/opt/pyenv/versions/${PYTHON_VERSION} \
     PYTHON_VERSION=${PYTHON_VERSION}
 
@@ -119,7 +119,7 @@ RUN cd /tmp && echo "Start by installing ${OPENSSL_VERSION}" \
     && make --quiet -j $(nproc) && make install --quiet
 
 ENV RBENV_ROOT=/opt/rbenv \
-    PATH=/opt/rbenv/shims:/opt/rbenv/bin:${PATH}
+    PATH=/opt/rbenv/versions/${RUBY_VERSION}/bin:/opt/rbenv/shims:/opt/rbenv/bin:${PATH}
 
 # Install ruby via rbenv
 # https://github.com/rbenv/ruby-build/wiki#ubuntudebianmint

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,4 +203,8 @@ COPY .inputrc .bashrc ${HOME}
 COPY git-prompt.sh ${HOME}/.config/git/
 COPY report_tool_infos.py /usr/local/bin/report_tool_infos
 
+# Make another copy at /opt/config
+COPY .inputrc .bashrc /opt/config/
+COPY git-prompt.sh /opt/config/
+
 CMD ["/bin/bash"]


### PR DESCRIPTION
This is unfortunate but I can't figure out why running openstudio versus ruby produces libexec/bundle and not exe/bundle

```shell

$ cat test_test.rb
require 'rubygems'

version = ">= 0.a"
puts Gem.respond_to?(:activate_bin_path)
puts Gem.activate_bin_path('bundler', 'bundle', version)

$ cat test_test.rb
system("which ruby")
system("ruby --version")
system("which bundle")
system("ruby test.rb")
```

Running with ruby:

```shell
root@test (develop %=)$ ruby test_test.rb
/opt/rbenv/versions/3.2.2/bin/ruby
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
/opt/rbenv/versions/3.2.2/bin/bundle
true
/opt/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/exe/bundle
```

Running with openstudio, notice it looks for libexec:

```shell
root@test (develop %=)$ /srv/data/jenkins/docker-volumes/ubuntu-2204/OS-build-release-v2/Products/openstudio test_test.rb
/opt/rbenv/versions/3.2.2/bin/ruby
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
/opt/rbenv/versions/3.2.2/bin/bundle
true
/opt/rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.10/libexec/bundle
```
